### PR TITLE
feat: write_note関数をcreate_noteとedit_noteに分割 (closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Minervaは、Claude Desktopと連携し、チャットからMarkdown文書の書
 Minervaを使用すると、Obsidianのナレッジベース（Vault）内のMarkdownファイルを効率的に管理・操作できます。
 Claude Desktopを通じて、以下の操作が可能です：
 
-- Markdownファイルの作成（write_note）
+- Markdownファイルの新規作成（create_note）
+- Markdownファイルの編集（edit_note）
 - Markdownファイルの読取（read_note）
 - Markdownファイル内のキーワード検索（search_notes）
+- Markdownファイルの作成・更新（write_note）※後方互換性のため提供
 
 ## 必要なもの
 

--- a/docs/note_operations.md
+++ b/docs/note_operations.md
@@ -4,14 +4,95 @@
 
 ## 1. 概要
 
-Minervaは、Obsidian vaultに対してノートの作成、読み取り、検索といった基本的な操作を提供します。これらの機能は、Python APIとして提供され、アプリケーションから呼び出すことができます。
+Minervaは、Obsidian vaultに対してノートの作成、編集、読み取り、検索といった基本的な操作を提供します。これらの機能は、Python APIとして提供され、アプリケーションから呼び出すことができます。
 
 ## 2. 主要機能
 
-### 2.1 ノートの作成・更新 (write_note)
+### 2.1 ノートの作成 (create_note)
+
+#### 機能概要
+指定されたテキストを新しいObsidian vault内のファイルに書き込みます。ファイルが既に存在する場合はエラーが発生します。コンテンツにはfrontmatter（メタデータ）が自動的に追加されます。
+
+#### パラメータ
+- `text`: ファイルに書き込むコンテンツ
+- `filename`: 書き込むファイル名（`.md`拡張子は自動的に追加されます）
+- `author`: frontmatterに追加する著者名（デフォルト: None、指定されない場合はシステム設定の著者名が使用されます）
+- `default_path`: サブディレクトリが指定されていない場合に使用するデフォルトディレクトリ（デフォルト: 環境設定のDEFAULT_NOTE_DIR値）
+
+#### 戻り値
+- 書き込まれたファイルのパス（Path型）
+
+#### 例外
+- `ValueError`: ファイル名が空または無効な場合
+- `FileExistsError`: ファイルが既に存在する場合
+- `pydantic.ValidationError`: ファイル名に禁止文字（`<>:"/\|?*`）が含まれる場合
+
+#### 使用例
+```python
+from minerva.tools import create_note
+
+# 基本的な使用例
+file_path = create_note(
+    text="This is a new note",
+    filename="example_note"  # .md拡張子は自動的に追加されます
+)
+print(f"新しいノートが作成されました: {file_path}")
+
+# 著者情報とデフォルトパスを指定する例
+file_path = create_note(
+    text="This is a note with author information",
+    filename="authored_note",
+    author="AI Assistant",
+    default_path="ai_generated"
+)
+print(f"著者情報付きノートが作成されました: {file_path}")
+```
+
+### 2.2 ノートの編集 (edit_note)
+
+#### 機能概要
+Obsidian vault内の既存のファイルを編集します。指定されたファイルが存在しない場合はエラーが発生します。コンテンツにはfrontmatter（メタデータ）が自動的に追加または更新されます。
+
+#### パラメータ
+- `text`: ファイルに書き込む新しいコンテンツ
+- `filename`: 編集するファイル名（`.md`拡張子は自動的に追加されます）
+- `author`: frontmatterに追加する著者名（デフォルト: None、指定されない場合はシステム設定の著者名が使用されます）
+- `default_path`: サブディレクトリが指定されていない場合に使用するデフォルトディレクトリ（デフォルト: 環境設定のDEFAULT_NOTE_DIR値）
+
+#### 戻り値
+- 編集されたファイルのパス（Path型）
+
+#### 例外
+- `ValueError`: ファイル名が空または無効な場合
+- `FileNotFoundError`: 編集対象のファイルが存在しない場合
+- `pydantic.ValidationError`: ファイル名に禁止文字（`<>:"/\|?*`）が含まれる場合
+
+#### 使用例
+```python
+from minerva.tools import edit_note
+
+# 基本的な使用例
+file_path = edit_note(
+    text="This is updated content",
+    filename="existing_note"  # .md拡張子は自動的に追加されます
+)
+print(f"ノートが更新されました: {file_path}")
+
+# 著者情報を更新する例
+file_path = edit_note(
+    text="Content with updated author information",
+    filename="existing_note",
+    author="Editor"
+)
+print(f"著者情報が更新されたノート: {file_path}")
+```
+
+### 2.3 ノートの作成・更新 (write_note) [非推奨]
 
 #### 機能概要
 指定されたテキストをObsidian vault内のファイルに書き込みます。ファイルが存在しない場合は新規作成し、存在する場合は上書きオプションに基づいて処理します。コンテンツにはfrontmatter（メタデータ）が自動的に追加されます。
+
+**注意**: この関数は後方互換性のために維持されていますが、新しいコードでは目的に応じて `create_note` または `edit_note` 関数を使用することを推奨します。
 
 #### パラメータ
 - `text`: ファイルに書き込むコンテンツ
@@ -73,7 +154,7 @@ file_path = write_note(
 print(f"frontmatter付きノートが保存されました: {file_path}")
 ```
 
-### 2.2 ノートの読み取り (read_note)
+### 2.4 ノートの読み取り (read_note)
 
 #### 機能概要
 Obsidian vault内の指定されたファイルからコンテンツを読み取ります。
@@ -97,7 +178,7 @@ content = read_note("/path/to/vault/example_note.md")
 print(f"ノートの内容: {content}")
 ```
 
-### 2.3 ノートの検索 (search_notes)
+### 2.5 ノートの検索 (search_notes)
 
 #### 機能概要
 Obsidian vault内のすべてのマークダウンファイル（`.md`）から指定されたキーワードを検索します。
@@ -160,8 +241,10 @@ for result in results:
 
 ### 4.1 ファイル操作のエラー
 
-- ファイルが存在し、上書きフラグがFalseの場合：`FileExistsError`が発生します
-- ファイルが存在せず、読み取りが要求された場合：`FileNotFoundError`が発生します
+- `create_note`: ファイルが既に存在する場合に`FileExistsError`が発生します
+- `edit_note`: ファイルが存在しない場合に`FileNotFoundError`が発生します
+- `write_note`: ファイルが存在し、上書きフラグがFalseの場合に`FileExistsError`が発生します
+- 読み取りが要求されたファイルが存在しない場合：`FileNotFoundError`が発生します
 - ファイル名が無効な場合：`ValueError`または`pydantic.ValidationError`が発生します
 
 ### 4.2 検索操作のエラー
@@ -174,3 +257,13 @@ for result in results:
 - 検索機能は、各ファイルの最初のマッチのみを返します
 - すべてのファイル操作はUTF-8エンコーディングを使用します
 - バイナリファイルは検索対象から除外されます
+
+## 6. ベストプラクティス
+
+### 6.1 関数の選択
+
+ノート操作において、意図を明確にするために以下のガイドラインに従うことを推奨します：
+
+- 新しいノートを作成する場合は、`create_note`を使用してください。これにより意図せずに既存のノートを上書きするリスクが低減されます。
+- 既存のノートを編集する場合は、`edit_note`を使用してください。これにより編集対象のノートが存在することが保証されます。
+- 後方互換性のために`write_note`関数も引き続き利用可能ですが、新しいコードでは意図を明確にするために`create_note`または`edit_note`の使用を推奨します。

--- a/minerva/tools.py
+++ b/minerva/tools.py
@@ -96,7 +96,7 @@ def _prepare_note_for_writing(
     filename: str,
     author: str | None = None,
     default_path: str = DEFAULT_NOTE_DIR
-) -> tuple[Path, Path, str]:
+) -> tuple[Path, str, str]:
     """
     Private function to prepare a note for writing.
 
@@ -142,11 +142,6 @@ def _prepare_note_for_writing(
         full_dir_path = full_dir_path / subdirs
     elif default_path:
         full_dir_path = full_dir_path / default_path
-
-    # Create directory if it doesn't exist
-    if not full_dir_path.exists():
-        full_dir_path.mkdir(parents=True, exist_ok=True)
-        logger.info(f"Created directory: {full_dir_path}")
 
     content = frontmatter.dumps(post)
 

--- a/minerva/tools.py
+++ b/minerva/tools.py
@@ -140,7 +140,7 @@ def _prepare_note_for_writing(
     full_dir_path = VAULT_PATH
     if str(subdirs) != ".":  # If a subdirectory is specified
         full_dir_path = full_dir_path / subdirs
-    elif default_path:
+    elif isinstance(default_path, str) and default_path.strip() != "":
         full_dir_path = full_dir_path / default_path
 
     content = frontmatter.dumps(post)


### PR DESCRIPTION
## 📝 概要
<!-- このプルリクエストで何が変更されるのか簡潔に説明してください -->
write_note関数をcreate_noteとedit_noteに分割

## 🔄 関連Issue
<!-- このPRが解決するIssue番号を記載してください（例: #123） -->
closes #11 

## 🛠 変更内容
<!-- 主な変更内容を箇条書きで記載してください -->
- `_prepare_note_for_writing` 内部関数に共通ロジックを抽出
- 新規ノート作成専用の `create_note` 関数の実装
- 既存ノート編集専用の `edit_note` 関数の実装
- 後方互換性のために `write_note` 関数を維持し、非推奨であることを文書化
- 新機能に対応する単体テストと統合テストの追加

## ✅ チェックリスト
<!-- 実装完了した項目にはチェックを入れてください -->
- [x] テストが追加・更新されている
- [x] ドキュメントが更新されている（必要な場合）
- [x] コードスタイルに準拠している
- [x] 既存の機能に影響がないことを確認した

## 📸 スクリーンショット
<!-- UIの変更がある場合、変更前と変更後のスクリーンショットを添付してください -->

## 🧪 テスト方法
<!-- レビュアーがこの変更をテストする方法を記載してください -->
1. 
2. 
3. 

## 📋 追加情報
<!-- 追加の情報や注意点があれば記載してください -->
