### PR TITLE
docs: Add guidelines for GitHub Copilot custom instructions and project patterns

### DIFF
--- a/.github/copilot/commit.md
+++ b/.github/copilot/commit.md
@@ -1,0 +1,60 @@
+# Commit Message Guidelines for Minerva
+
+The Minerva project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for commit messages. Detailed rules are described in `docs/github_workflow.md`.
+
+## Commit Message Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Main Types
+- `feat`: A new feature
+- `fix`: A bug fix
+- `docs`: Documentation only changes
+- `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- `refactor`: A code change that neither fixes a bug nor adds a feature
+- `perf`: A code change that improves performance
+- `test`: Adding missing tests or correcting existing tests
+- `build`: Changes that affect the build system or external dependencies
+- `ci`: Changes to CI configuration files and scripts
+- `chore`: Other changes that don't modify source or test files
+
+## Scope
+You can specify a scope in parentheses to indicate the section of the codebase affected:
+- `(obsidian)`
+- `(claude)`
+- `(file-handler)`
+- `(tools)`
+- `(config)`
+etc.
+
+## Examples
+- `feat(obsidian): Add support for note synchronization`
+- `fix(tools): Fix incorrect path handling in search_notes function`
+- `docs: Update installation instructions`
+- `test(file-handler): Add unit tests for write_note function`
+- `refactor: Move common functions to utils module`
+
+Include related issue numbers in the footer:
+```
+Issue #42
+```
+
+Or to close multiple issues:
+```
+Closes #42, #43
+```
+
+## Language
+Commit messages must be written in English.
+```
+feat(tools): Add file search functionality
+
+Implement fast search using search indices
+Closes #24
+```

--- a/.github/copilot/patterns/error_handling.md
+++ b/.github/copilot/patterns/error_handling.md
@@ -1,0 +1,128 @@
+# Error Handling Patterns for Minerva
+
+## Basic Principles
+
+The Minerva project follows these principles for error handling:
+
+1. **Exception Propagation and Transformation**: Convert low-level exceptions into more meaningful high-level exceptions
+2. **Appropriate Logging**: Log all exceptions at appropriate log levels
+3. **Clear Error Messages**: Provide user-friendly error messages for end users
+4. **Detailed Context**: Include helpful information for debugging in errors
+
+## Exception Types
+
+### 1. Input Validation Errors
+
+Example of input validation using Pydantic:
+
+```python
+class FileOperationRequest(BaseModel):
+    """Base request model for file operations."""
+
+    directory: str = Field(description="Directory for the file operation")
+    filename: str = Field(description="Name of the file")
+
+    @field_validator("filename")
+    def validate_filename(cls, v):
+        """Validate the filename."""
+        if not v:
+            raise ValueError("Filename cannot be empty")
+        if os.path.isabs(v):
+            raise ValueError("Filename cannot be an absolute path")
+        if any(char in v for char in FORBIDDEN_CHARS):
+            raise ValueError(
+                f"Filename contains forbidden characters: {FORBIDDEN_CHARS}"
+            )
+        return v
+```
+
+### 2. File Operation Errors
+
+Error handling related to file operations:
+
+```python
+def write_file(request: FileWriteRequest) -> Path:
+    """Write the content to a file in the specified directory."""
+    file_path = _get_validated_file_path(request.directory, request.filename)
+
+    # Ensure the directory exists
+    if not file_path.parent.exists():
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if file_path.exists() and not request.overwrite:
+        raise FileExistsError(
+            f"File {file_path} already exists and overwrite is set to False"
+        )
+
+    # Write the content to the file
+    try:
+        with open(file_path, "w", encoding=ENCODING) as f:
+            f.write(request.content)
+        return file_path
+    except IOError as e:
+        logger.error("Error writing to file %s: %s", file_path, e)
+        raise IOError(f"Failed to write to file {file_path}: {e}") from e
+```
+
+## try-except Patterns
+
+### 1. Basic Pattern
+
+```python
+try:
+    # Potentially exception-raising operation
+    result = potentially_failing_operation()
+except SpecificException as e:
+    # Handle the exception appropriately
+    logger.error("Operation failed: %s", e)
+    # Raise a more specific exception if needed
+    raise CustomException("Failed to perform operation") from e
+```
+
+### 2. Using finally Blocks
+
+When resource cleanup is needed:
+
+```python
+resource = None
+try:
+    resource = acquire_resource()
+    result = use_resource(resource)
+    return result
+except Exception as e:
+    logger.error("Resource operation failed: %s", e)
+    raise
+finally:
+    # Resource cleanup (executed even if an exception occurs)
+    if resource:
+        release_resource(resource)
+```
+
+### 3. Using else Blocks
+
+Processing that only executes if no exception occurs:
+
+```python
+try:
+    data = parse_input(user_input)
+except ValueError as e:
+    logger.error("Invalid input: %s", e)
+    raise InvalidInputError("Input could not be parsed") from e
+else:
+    # Only executes if no exception occurred
+    process_valid_data(data)
+```
+
+## Error Handling Best Practices
+
+1. **Catch Specific Exceptions**: Catch specific exception classes rather than `Exception`
+
+2. **Provide Error Context**: Include information in error messages that clearly explains what happened
+
+3. **Preserve the Cause of Exceptions**: Use the `raise ... from e` syntax to preserve the original exception
+
+4. **Appropriate Error Abstraction**: At API boundaries, return errors at an appropriate level of abstraction that doesn't leak internal implementation details
+
+5. **Consistent Error Responses**: Keep error messages returned to users in a consistent format
+
+6. **Early Input Validation**: Validate inputs early in the process to detect invalid inputs as soon as possible

--- a/.github/copilot/patterns/file_operations.md
+++ b/.github/copilot/patterns/file_operations.md
@@ -1,0 +1,175 @@
+# File Operation Patterns for Minerva
+
+## Basic Principles
+
+The Minerva project follows these principles for file operations:
+
+1. **Path Validation**: All file paths are validated before use
+2. **Encoding Consistency**: A consistent encoding (UTF-8) is used for all text file operations
+3. **Directory Existence Check**: Directory existence is verified before writing files, and created if necessary
+4. **Atomic Operations**: Atomic operations are used when possible to ensure file operation reliability
+
+## File Path Validation
+
+Use the following pattern for file path validation:
+
+```python
+def _get_validated_file_path(directory: str, filename: str) -> Path:
+    """Validate and return the full file path."""
+    dirpath = Path(directory)
+    # Check if the directory is absolute
+    if not dirpath.is_absolute():
+        raise ValueError("Directory must be an absolute path")
+
+    return dirpath / filename
+```
+
+## File Writing
+
+Use the following pattern for file writing operations:
+
+```python
+def write_file(request: FileWriteRequest) -> Path:
+    """Write the content to a file in the specified directory."""
+    file_path = _get_validated_file_path(request.directory, request.filename)
+
+    # Ensure the directory exists
+    if not file_path.parent.exists():
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if file_path.exists() and not request.overwrite:
+        raise FileExistsError(
+            f"File {file_path} already exists and overwrite is set to False"
+        )
+
+    # Write the content to the file
+    with open(file_path, "w", encoding=ENCODING) as f:
+        f.write(request.content)
+    return file_path
+```
+
+## File Reading
+
+Use the following pattern for file reading operations:
+
+```python
+def read_file(request: FileReadRequest) -> str:
+    """Read the content from a file in the specified directory."""
+    file_path = _get_validated_file_path(request.directory, request.filename)
+
+    # Check if the file exists
+    if not file_path.exists():
+        raise FileNotFoundError(f"File {file_path} does not exist")
+
+    # Read the content from the file
+    with open(file_path, "r", encoding=ENCODING) as f:
+        content = f.read()
+    return content
+```
+
+## Binary File Detection
+
+Pattern for detecting binary files to avoid accidentally processing them as text files:
+
+```python
+def is_binary_file(file_path: Path) -> bool:
+    """Check if a file is binary."""
+    try:
+        with open(file_path, "rb") as f:
+            chunk = f.read(1024)
+            return b"\0" in chunk
+    except (IOError, PermissionError) as e:
+        logger.warning("Error checking if file is binary: %s", e)
+        return False
+```
+
+## Subdirectory Processing
+
+Use the following pattern for handling subdirectories in Obsidian notes:
+
+```python
+def _build_file_path(filename: str, default_path: str = DEFAULT_NOTE_DIR) -> tuple[Path, str]:
+    """
+    Resolve and build the complete file path from a filename.
+
+    Args:
+        filename: The filename (may include subdirectories)
+        default_path: The default path to use if no subdirectory is specified
+
+    Returns:
+        tuple: (directory_path, base_filename)
+    """
+    # Parse path components
+    path_parts = Path(filename)
+    subdirs = path_parts.parent
+    base_filename = path_parts.name
+
+    # Create final directory path
+    full_dir_path = VAULT_PATH
+    if str(subdirs) != ".":  # If subdirectory is specified
+        full_dir_path = full_dir_path / subdirs
+    elif isinstance(default_path, str) and default_path.strip() != "":
+        full_dir_path = full_dir_path / default_path
+
+    return full_dir_path, base_filename
+```
+
+## File Searching
+
+Use the following pattern for file search operations:
+
+```python
+def search_keyword_in_files(config: SearchConfig) -> list[SearchResult]:
+    """
+    Search for a keyword in files within a directory.
+    """
+    matching_files = []
+
+    # Create a regex pattern if case sensitivity is disabled
+    if not config.case_sensitive:
+        pattern = re.compile(re.escape(config.keyword), re.IGNORECASE)
+
+    try:
+        # Recursively search the directory
+        for root, _, files in os.walk(config.directory):
+            for file_name in files:
+                # Check if the file matches the specified extensions
+                if config.file_extensions is not None:
+                    ext = os.path.splitext(file_name)[1].lower()
+                    if ext not in config.file_extensions:
+                        continue
+
+                file_path = Path(root) / file_name
+
+                # Skip binary files
+                if is_binary_file(file_path):
+                    continue
+
+                try:
+                    # Open the file and search for the keyword
+                    with open(file_path, "r", encoding=ENCODING) as file:
+                        for line_num, line in enumerate(file, 1):
+                            if config.case_sensitive:
+                                found = config.keyword in line
+                            else:
+                                found = pattern.search(line) is not None
+
+                            if found:
+                                result = SearchResult(
+                                    file_path=str(file_path),
+                                    line_number=line_num,
+                                    context=line.strip(),
+                                )
+                                matching_files.append(result)
+                                break  # Stop after finding first match in this file
+                except (UnicodeDecodeError, PermissionError):
+                    # Ignore read errors and continue
+                    sanitized_path = str(file_path).replace('\n', '_').replace('\r', '_')
+                    logger.warning("Could not read file %s. Skipping.", sanitized_path)
+
+    except Exception as e:
+        logger.error("Error during search: %s", e)
+        raise
+
+    return matching_files
+```

--- a/.github/copilot/patterns/frontmatter.md
+++ b/.github/copilot/patterns/frontmatter.md
@@ -1,0 +1,212 @@
+# Frontmatter Processing Patterns for Minerva
+
+## Basic Concepts
+
+The Minerva project uses the `python-frontmatter` library to process frontmatter (YAML format metadata) in Obsidian notes. The following basic principles are observed for frontmatter processing:
+
+1. **Consistency**: Use a consistent frontmatter format for all notes
+2. **Metadata Preservation**: Respect and preserve existing frontmatter data
+3. **Automatic Addition**: Automatically add or update necessary metadata
+4. **Separation**: Separate frontmatter processing from file operations
+
+## Frontmatter Generation
+
+Pattern for generating or updating frontmatter for new or existing notes:
+
+```python
+def _generate_note_metadata(
+    text: str,
+    author: str | None = None,
+    is_new_note: bool = True,
+    existing_frontmatter: dict | None = None,
+) -> frontmatter.Post:
+    """
+    Generate or update YAML frontmatter metadata for a note.
+
+    Args:
+        text: The text content of the note (with or without existing frontmatter)
+        author: The author name to include in the metadata
+        is_new_note: Whether this is a new note (True) or an update to existing note (False)
+        existing_frontmatter: Existing frontmatter data from the file (if any)
+
+    Returns:
+        frontmatter.Post: Post object with properly processed frontmatter
+    """
+    # Get current time in ISO format
+    now = datetime.now().isoformat()
+
+    # Check and load frontmatter
+    has_frontmatter = text.startswith("---\n")
+    if has_frontmatter:
+        # Load existing frontmatter
+        post = frontmatter.loads(text)
+    else:
+        # Create new frontmatter object
+        post = frontmatter.Post(text)
+
+    # Add author information
+    post.metadata["author"] = author or DEFAULT_NOTE_AUTHOR
+
+    # Preserve created field from existing frontmatter
+    if existing_frontmatter and "created" in existing_frontmatter:
+        post.metadata["created"] = existing_frontmatter["created"]
+
+    # Add created field for new notes (don't overwrite if exists)
+    if is_new_note and "created" not in post.metadata:
+        post.metadata["created"] = now
+
+    # Add updated field for note updates (always update with current time)
+    if not is_new_note:
+        post.metadata["updated"] = now
+
+    return post
+```
+
+## Reading Existing Frontmatter
+
+Pattern for reading frontmatter from existing files:
+
+```python
+def _read_existing_frontmatter(file_path: Path) -> dict | None:
+    """
+    Read and extract frontmatter metadata from an existing file.
+
+    Args:
+        file_path: Path to the file to read
+
+    Returns:
+        dict | None: Existing frontmatter metadata as a dictionary, or:
+            - Empty dict ({}) if the file exists but has no frontmatter
+            - None if the file doesn't exist or can't be read as text
+    """
+    if not file_path.exists():
+        return None
+
+    try:
+        with open(file_path, "r") as f:
+            content = f.read()
+            if content.startswith("---\n"):  # If frontmatter exists
+                post = frontmatter.loads(content)
+                return post.metadata
+            # No frontmatter found in file
+            return {}
+    except PermissionError as e:
+        logger.error("Permission denied when reading file %s: %s", file_path, e)
+        raise
+    except UnicodeDecodeError as e:
+        logger.warning(
+            "File %s cannot be decoded as text (possibly binary): %s", file_path, e
+        )
+        return None
+    except Exception as e:
+        logger.warning("Failed to read existing file %s for metadata: %s", file_path, e)
+        return None
+```
+
+## Note Assembly
+
+Pattern for assembling a note by combining frontmatter and content:
+
+```python
+def _assemble_complete_note(
+    text: str,
+    filename: str,
+    author: str | None = None,
+    default_path: str = DEFAULT_NOTE_DIR,
+    is_new_note: bool = True,
+) -> tuple[Path, str, str]:
+    """
+    Assemble a complete note by combining file path resolution, metadata generation, and content preparation.
+
+    Args:
+        text: The content to write to the file
+        filename: The name of the file to write
+        author: The author name to add to the frontmatter
+        default_path: The default directory to save the file
+        is_new_note: Whether this is a new note (True) or an update to an existing note (False)
+
+    Returns:
+        tuple: (full_dir_path, base_filename, prepared_content)
+    """
+    # Build file path
+    full_dir_path, base_filename = _build_file_path(filename, default_path)
+
+    # Check existing frontmatter
+    file_path = full_dir_path / base_filename
+    existing_frontmatter = _read_existing_frontmatter(file_path)
+
+    # Generate metadata
+    post = _generate_note_metadata(
+        text=text,
+        author=author,
+        is_new_note=is_new_note,
+        existing_frontmatter=existing_frontmatter,
+    )
+
+    # Convert Post object to string with frontmatter
+    content = frontmatter.dumps(post)
+
+    return full_dir_path, base_filename, content
+```
+
+## Parsing and Manipulating Frontmatter
+
+Pattern for parsing and manipulating frontmatter:
+
+```python
+# Extract frontmatter and content from a note
+content = read_note(str(file_path))
+post = frontmatter.loads(content)
+
+# Get and manipulate metadata
+created_date = post.metadata.get('created')
+tags = post.metadata.get('tags', [])
+tags.append('new-tag')
+post.metadata['tags'] = tags
+
+# Add metadata
+post.metadata['status'] = 'completed'
+
+# Convert to string with frontmatter and content
+updated_content = frontmatter.dumps(post)
+```
+
+## Date Time Format
+
+Minerva standardizes date and time information in frontmatter using ISO 8601 format:
+
+```python
+# Get current date time in ISO 8601 format
+now = datetime.now().isoformat()  # Example: '2025-05-02T12:34:56.789012'
+
+# Add to frontmatter
+post.metadata["created"] = now
+```
+
+## Processing Tags and Attributes
+
+Pattern for processing list-format metadata such as tags or attributes:
+
+```python
+# Get tags (using empty list as default value)
+tags = post.metadata.get('tags', [])
+
+# Convert to list if not already a list (e.g., if it's a string)
+if not isinstance(tags, list):
+    tags = [tags]
+
+# Add a tag
+if 'new-tag' not in tags:
+    tags.append('new-tag')
+
+# Set updated tags in metadata
+post.metadata['tags'] = tags
+```
+
+## Best Practices
+
+1. **Separate Functions**: Perform frontmatter processing in separate functions, isolated from file operations
+2. **Respect Existing Data**: Preserve existing frontmatter data whenever possible
+3. **Appropriate Default Values**: Provide appropriate default values for required fields
+4. **Consistent Schema**: Maintain a consistent schema (field names and types) for frontmatter
+5. **Error Handling**: Properly handle and log errors during frontmatter processing

--- a/.github/copilot/patterns/logging.md
+++ b/.github/copilot/patterns/logging.md
@@ -1,0 +1,77 @@
+# Logging Patterns for Minerva
+
+Please use the following patterns for logging in the Minerva project.
+
+## Getting a Logger
+
+Get a module-specific logger at the top of each module:
+
+```python
+import logging
+
+# Get logger at the module level
+logger = logging.getLogger(__name__)
+```
+
+## Using Different Log Levels
+
+- **DEBUG**: Detailed information useful during development or debugging
+  ```python
+  logger.debug("Processing file: %s", file_path)
+  ```
+
+- **INFO**: Progress information for normal operations
+  ```python
+  logger.info("File written to %s", file_path)
+  ```
+
+- **WARNING**: Situations that might cause issues but allow processing to continue
+  ```python
+  logger.warning("Could not read file %s. Skipping.", sanitized_path)
+  ```
+
+- **ERROR**: Errors that prevent a function from being executed
+  ```python
+  logger.error("Error writing file: %s", e)
+  ```
+
+- **CRITICAL**: Serious situations that make the entire application unable to function
+  ```python
+  logger.critical("Database connection failed: %s", e)
+  ```
+
+## Important Rules
+
+1. **Do Not Use f-strings**
+   - Using f-strings causes string evaluation to occur even if the log level is disabled
+   - Use the older string format style instead
+
+   ```python
+   # Correct example
+   logger.debug("Found %d matching files for query '%s'", len(results), query)
+   
+   # Incorrect example - do not use
+   logger.debug(f"Found {len(results)} matching files for query '{query}'")
+   ```
+
+2. **Logging Exception Information**
+
+   ```python
+   try:
+       # Some operation
+       process_file(file_path)
+   except Exception as e:
+       # Log with stack trace
+       logger.exception("Error processing file %s: %s", file_path, e)
+       # Or
+       logger.error("Error processing file %s: %s", file_path, e)
+       raise
+   ```
+
+3. **Handling Sensitive Information**
+   - Do not log sensitive information such as passwords or API keys
+   - Sanitize user input data before logging it
+   ```python
+   sanitized_path = str(file_path).replace('\n', '_').replace('\r', '_')
+   logger.info("Processing file: %s", sanitized_path)
+   ```

--- a/.github/copilot/patterns/testing.md
+++ b/.github/copilot/patterns/testing.md
@@ -1,0 +1,116 @@
+# Testing Patterns for Minerva
+
+## Arrange-Act-Assert (AAA) Pattern
+
+The Minerva project uses the AAA (Arrange-Act-Assert) pattern for all tests. This pattern structures tests clearly and makes code behavior easy to understand.
+
+### 1. Arrange
+Set up the system under test in an appropriate initial state.
+- Prepare test data
+- Set up mock objects
+- Build prerequisites
+
+```python
+# ==================== Arrange ====================
+request = FileWriteRequest(
+    directory=temp_dir,
+    filename="test.txt",
+    content="Hello, World!",
+    overwrite=True,
+)
+```
+
+### 2. Act
+Execute the code being tested. This is typically a single function or method call.
+
+```python
+# ==================== Act ====================
+file_path = write_file(request)
+```
+
+### 3. Assert
+Verify that the results are as expected.
+
+```python
+# ==================== Assert ====================
+assert file_path == Path(temp_dir) / "test.txt"
+assert file_path.exists()
+with open(file_path, "r", encoding=ENCODING) as f:
+    content = f.read()
+    assert content == "Hello, World!"
+```
+
+## Test Docstrings
+
+Include a docstring with the following structure for each test method:
+
+```python
+def test_write_file_success(self, temp_dir):
+    """Test writing a file successfully.
+
+    Arrange:
+        - Create a file write request with test content
+    Act:
+        - Call write_file with the request
+    Assert:
+        - File is created at the expected path
+        - File exists in the filesystem
+        - File content matches the input
+    """
+    # Test implementation
+```
+
+## Fixtures
+
+Extract common setup code into pytest fixtures for reuse:
+
+```python
+@pytest.fixture
+def temp_dir():
+    """Fixture that provides a temporary directory for file operations."""
+    with TemporaryDirectory() as tempdir:
+        yield tempdir
+```
+
+## Mocking
+
+Properly mock external dependencies to isolate your tests:
+
+```python
+@pytest.fixture
+def mock_write_setup(self, tmp_path):
+    """Fixture providing common mock setup for write tests."""
+    with (
+        mock.patch("minerva.tools.write_file") as mock_write_file,
+        mock.patch("minerva.tools.VAULT_PATH", tmp_path),
+    ):
+        yield {"mock_write_file": mock_write_file, "tmp_path": tmp_path}
+```
+
+## Parameterized Tests
+
+Use parameterized tests to efficiently test multiple test cases:
+
+```python
+@pytest.mark.parametrize(
+    "filename,expected_message",
+    [
+        ("", "Filename cannot be empty"),
+        ("/absolute/path/to/file.txt", "Filename cannot be an absolute path"),
+    ],
+)
+def test_invalid_filename_validation(self, temp_dir, filename, expected_message):
+    # Test implementation
+```
+
+## Edge Cases
+
+Test not only basic functionality but also edge cases such as:
+- Empty inputs
+- Invalid inputs
+- Boundary values
+- Resource constraints (large files, many files, etc.)
+
+## Test Independence
+
+Each test should be able to run independently without relying on other tests. Avoid sharing state between tests.

--- a/.github/copilot/python.md
+++ b/.github/copilot/python.md
@@ -1,0 +1,32 @@
+# Python Coding Standards for Minerva
+
+## General Guidelines
+- Python code must comply with PEP 8 style guide
+- Limit line length to 88 characters (Ruff compliant)
+- Use 4 spaces for indentation
+- Use CamelCase for class names, snake_case for function and method names
+- Use ALL_CAPS for constants
+
+## Logging Guidelines
+- Do NOT use f-strings when logging!
+  - Correct example: `logger.info("Found %s files matching the query: %s", len(matching_files), query)`
+  - Incorrect example: `logger.info(f"Found {len(matching_files)} files matching the query: {query}")`
+- Use appropriate log levels (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+- Log all exceptions with `logger.error()` or `logger.exception()`
+
+## Imports
+Group imports in the following order:
+1. Standard library (os, pathlib, etc)
+2. Third-party libraries (pydantic, frontmatter, etc)
+3. Local modules (minerva.*)
+
+## Error Handling
+- Catch specific exceptions (concrete exception classes rather than Exception)
+- Provide clear error messages to users
+- Use Pydantic models for input validation
+
+## Testing
+- Create unit tests for all functions and methods
+- Structure tests following the AAA pattern (Arrange-Act-Assert)
+- Include appropriate docstrings in test functions
+- Update corresponding tests when the code being tested changes

--- a/.github/copilot/reference.md
+++ b/.github/copilot/reference.md
@@ -1,0 +1,35 @@
+# Minerva Project Reference
+
+## Project Overview
+Minerva is a tool that integrates with Claude Desktop to automate tasks such as exporting Markdown documents from chat conversations.
+
+## Important References
+- Always refer to `README.md` before starting development
+- Project detailed specifications are in documents within the `docs/` directory
+  - Specifically, `docs/requirements.md` contains project requirements
+  - `docs/technical_spec.md` contains technical specifications
+  - `docs/note_operations.md` contains specifications for note operation features
+
+## Architecture
+- MCP Server (FastMCP)
+- Tool implementation (tools.py)
+  - Functions such as write_note, read_note, search_notes, etc.
+- File operation module (file_handler.py)
+- Configuration management (config.py)
+
+## Development Environment
+- Python 3.12+
+- uv package manager
+
+## Dependencies
+Main dependencies:
+- mcp[cli]
+- pydantic
+- python-dotenv
+- python-frontmatter
+
+Development dependencies:
+- mypy
+- pytest
+- pytest-cov
+- pytest-mock

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Minervaの目標は、Claude Desktopと連携してObsidianの操作を自然言
 - [開発ワークフロー](docs/development_workflow.md) - 開発プロセス、ブランチ戦略、コードレビュー、リリースフロー
 - [GitHub開発プロセス](docs/github_workflow.md) - GitHubを使用した開発プロセスの詳細
 - [Issueと PR の効果的な活用ガイド](docs/issue_pr_guide.md) - IssueとPRの効果的な活用方法
+- [GitHub Copilot カスタム指示ガイドライン](docs/copilot_guidelines.md) - GitHub Copilotのカスタム指示を使用した開発ガイドライン
 
 ## 開発ガイド
 

--- a/docs/copilot_guidelines.md
+++ b/docs/copilot_guidelines.md
@@ -1,0 +1,163 @@
+# GitHub Copilot カスタム指示ガイドライン
+
+このドキュメントでは、Minervaプロジェクトにおける GitHub Copilot のリポジトリカスタム指示の設定と使用方法について説明します。
+
+## 1. 概要
+
+Minervaプロジェクトでは、開発効率の向上と一貫したコード品質を保つために、GitHub Copilotのリポジトリカスタム指示機能を活用しています。これにより、プロジェクト固有のコーディング規約や開発プラクティスをCopilotに伝えることが可能になり、より適切なコード補完とサジェスチョンが得られます。
+
+## 2. カスタム指示の構成
+
+カスタム指示は `.github/copilot/` ディレクトリに配置されており、以下のような構成になっています：
+
+```
+.github/
+  copilot/
+    reference.md      # プロジェクト全体のリファレンス情報
+    python.md         # Python固有のコーディング規約
+    commit.md         # コミットメッセージルール
+    patterns/         # 特定のパターンやコンポーネント向け指示
+      logging.md      # ロギングに関する指示
+      testing.md      # テストに関する指示
+      error_handling.md  # エラー処理に関する指示
+      file_operations.md # ファイル操作に関する指示
+      frontmatter.md  # フロントマター処理に関する指示
+```
+
+## 3. 各指示ファイルの役割
+
+### 3.1 reference.md
+
+プロジェクト全体に関するリファレンス情報を提供します：
+- プロジェクト概要
+- 重要な参照先ドキュメント（README.md、docs/以下のファイル）
+- アーキテクチャ構成
+- 開発環境と依存関係
+
+### 3.2 python.md
+
+Pythonコーディングに関する規約とベストプラクティスを定義します：
+- PEP 8準拠のスタイルガイド
+- インデントや命名規則
+- インポート順序
+- 特にロギング時のf-strings禁止などの重要ルール
+
+### 3.3 commit.md
+
+コミットメッセージに関するガイドラインを提供します：
+- Conventional Commits規約に基づく形式
+- 主なタイプ（feat, fix, docs, etc.）の説明
+- スコープ指定の方法
+- 具体的な例
+- 日本語によるコミットメッセージの書き方
+
+### 3.4 patterns/logging.md
+
+ロギングに関する具体的なパターンと例を提供します：
+- ロガーの取得方法
+- ログレベルの適切な使い分け
+- f-strings禁止の理由と代替手段
+- 例外情報のロギング方法
+- 機密情報の扱い
+
+### 3.5 patterns/testing.md
+
+テストに関するパターンとベストプラクティスを提供します：
+- AAAパターン（Arrange-Act-Assert）の実装方法
+- テストdocstringの形式
+- フィクスチャとモックの適切な使用法
+- パラメータ化テストの実装
+- エッジケースのテスト方法
+
+### 3.6 patterns/error_handling.md
+
+エラー処理に関するパターンを提供します：
+- 基本的なtry-exceptパターン
+- 例外の伝播と変換
+- コンテキスト情報の提供
+- リソースクリーンアップのためのfinallyブロック
+
+### 3.7 patterns/file_operations.md
+
+ファイル操作に関するパターンを提供します：
+- パスの検証と正規化
+- ディレクトリの存在確認と作成
+- ファイル読み書きの標準パターン
+- バイナリファイルの検出
+
+### 3.8 patterns/frontmatter.md
+
+フロントマター処理に関するパターンを提供します：
+- フロントマターの生成と更新
+- 既存フロントマターの読み取り
+- 日時形式の統一
+- タグと属性の処理
+
+## 4. 開発者向けガイドライン
+
+### 4.1 カスタム指示の使い方
+
+1. **新機能開発時**：
+   - 開発開始前に `reference.md` を参照し、関連するドキュメントを確認する
+   - 実装時は `python.md` の規約に従う
+   - 特定のパターン（ロギング、エラー処理など）を実装する際は、対応する`patterns/`内のファイルを参照する
+
+2. **コミット時**：
+   - `commit.md` に従ってコミットメッセージを作成する
+   - 関連するIssue番号を適切に記載する
+
+3. **テスト作成時**：
+   - `patterns/testing.md` に従いAAAパターンでテストを構造化する
+   - 適切なdocstringをテスト関数に含める
+
+### 4.2 カスタム指示の更新
+
+カスタム指示の内容は、プロジェクトの進化に伴い更新が必要になる場合があります：
+
+1. 新しいパターンやベストプラクティスが確立された場合、対応するファイルを更新または新規作成する
+2. 変更はプルリクエストを通じて行い、チームでレビューする
+3. 更新内容はチーム全体に通知し、必要に応じて説明を行う
+
+## 5. VSCodeでのCopilotの設定
+
+VSCodeでGitHub Copilotを効果的に使用するための設定：
+
+1. **Copilotの有効化**：
+   - VSCode拡張機能「GitHub Copilot」をインストール
+   - GitHub アカウントでサインイン
+
+2. **推奨設定**：
+   ```json
+   {
+     "github.copilot.enable": true,
+     "github.copilot.editor.enableAutoCompletions": true,
+     "editor.inlineSuggest.enabled": true
+   }
+   ```
+
+3. **キーボードショートカット**：
+   - 提案を受け入れる: `Tab`
+   - 提案を拒否する: `Esc`
+   - 次の提案を表示: `Alt+]`
+   - 前の提案を表示: `Alt+[`
+
+## 6. 参考リンク
+
+- [GitHub Copilot公式ドキュメント](https://docs.github.com/en/copilot)
+- [リポジトリカスタム指示の追加](https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot?tool=vscode)
+- [Conventional Commits](https://www.conventionalcommits.org/ja/v1.0.0/)
+- [Minervaプロジェクトのgithub_workflow.md](../github_workflow.md)
+
+## 7. よくある質問
+
+### Q: カスタム指示が反映されていないようです。どうすればいいですか？
+
+A: VSCodeを再起動し、`.github/copilot/` ディレクトリが正しく作成されていることを確認してください。また、GitHub Copilot拡張機能が最新バージョンであることも確認してください。
+
+### Q: カスタム指示の優先順位はどうなっていますか？
+
+A: 一般的に、より具体的なファイル（例：`patterns/logging.md`）の内容は、より一般的なファイル（例：`python.md`）よりも優先されます。ただし、これは絶対的なルールではなく、Copilotの実装に依存します。
+
+### Q: 新しいパターンを追加したい場合はどうすればいいですか？
+
+A: `.github/copilot/patterns/` ディレクトリに新しいMarkdownファイルを作成し、パターンの説明と具体的な例を記載してください。その後、このドキュメントを更新して新しいパターンについて説明を追加してください。


### PR DESCRIPTION
## 概要
- GitHub Copilotのカスタムインストラクションとプロジェクトパターンに関するガイドラインを追加
- .github/copilot/配下に各種パターン・リファレンス・ガイドを新設
- README.md, docs/copilot_guidelines.md も更新

🤖 Generated with GitHub Copilot