### PR TITLE
[PR] config.pyのMinervaConfigから後方互換性への言及を削除

### DIFF
--- a/src/minerva/config.py
+++ b/src/minerva/config.py
@@ -14,7 +14,7 @@ class MinervaConfig:
 
     This class encapsulates all configuration parameters needed for
     Minerva's operation, providing a clean interface for dependency injection
-    and testing while maintaining backward compatibility.
+    and testing.
     """
 
     vault_path: Path


### PR DESCRIPTION
## 📝 概要
MinervaConfigクラスのdocstringから古い「後方互換性を維持しながら」という記述を削除し、現在の設計思想を正確に反映するように文書を更新しました。

## 🔄 関連Issue
closes #65

## 🛠 変更内容
- `src/minerva/config.py`のMinervaConfigクラスdocstringから"while maintaining backward compatibility"を削除
- 現在のアーキテクチャに即した簡潔な説明に変更

## ✅ チェックリスト
- [x] テストが追加・更新されている（既存テストで十分）
- [x] ドキュメントが更新されている（該当変更）
- [x] コードスタイルに準拠している
- [x] 既存の機能に影響がないことを確認した

## 📸 スクリーンショット
<\!-- UIの変更はありません -->

## 🧪 テスト方法
1. `uv run pytest tests/test_config.py` でconfig関連のテストを実行
2. 全テストが正常に通過することを確認
3. lintとフォーマットチェックが通過することを確認

## 📋 追加情報
プロジェクトが新しいアーキテクチャに移行済みのため、後方互換性への言及は開発者の混乱を招く可能性がありました。

## 🤖 AI生成情報
- [x] この Pull Request は AI アシスタントによって作成されました
- AIモデル: Claude Sonnet 4
- 作成日時: 2025-06-10 15:00
- 生成根拠: Issue #65の要求に基づいた文書の整理とアップデート