### PR TITLE
refactor: remove sys.path manipulation and optimize editable install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ If you prefer to use uv commands directly:
 - Run formatting: `uv run ruff format`
 - Type checking: `uv run mypy src tests`
 - Run MCP inspector: `uv run mcp dev src/minerva/server.py:mcp`
-- Install to Claude Desktop: `uv run mcp install src/minerva/server.py:mcp -f .env --with python-frontmatter`
+- Install to Claude Desktop: `uv run mcp install src/minerva/server.py:mcp -f .env --with-editable .`
 - Check for trailing whitespace: `python scripts/check_trailing_whitespace.py`
 - Fix trailing whitespace (in-place): `find . -type f \( -name "*.py" -o -name "*.md" -o -name "*.yml" -o -name "*.yaml" \) -not -path "*/.git/*" -not -path "*/__pycache__/*" -not -path "*/.venv/*" -not -path "*/venv/*" -not -path "*/.egg-info/*" -exec sed -i 's/[ \t]*$//' {} \;`
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ uv run mcp dev src/minerva/server.py:mcp
 
 `-f .env` フラグは、環境変数を設定するための `.env` ファイルを指定します。このファイルには、プロジェクトの設定に必要な変数が含まれています。
 ```bash
-uv run mcp install src/minerva/server.py:mcp -f .env --with python-frontmatter
+uv run mcp install src/minerva/server.py:mcp -f .env --with-editable .
 ```
 
-`python-frontmatter`パッケージはMarkdownファイルのYAML形式のメタデータ（frontmatter）を処理するために必要です。
+**重要**: `--with-editable .` オプションにより、プロジェクトをeditable modeでインストールします。これにより、Claude Desktop環境でも`minerva`パッケージとその依存関係（`python-frontmatter`など）が適切に認識されます。
 
 ## Claude Desktop での使い方
 

--- a/docs/development_setup.md
+++ b/docs/development_setup.md
@@ -189,8 +189,10 @@ uv run mcp dev src/minerva/server.py:mcp
 ### Claude Desktopへのインストール
 
 ```bash
-uv run mcp install src/minerva/server.py:mcp -f .env --with python-frontmatter
+uv run mcp install src/minerva/server.py:mcp -f .env --with-editable .
 ```
+
+**重要**: `--with-editable .` オプションにより、プロジェクトをeditable modeでインストールします。これにより、Claude Desktop環境でも`minerva`パッケージとその依存関係が適切に認識されます。
 
 ### ログの確認（MacOS）
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -191,26 +191,6 @@ Minervaプロジェクトでは、以下の2つの異なる環境での依存関
    - `uv run --with`コマンドによる一時的な実行環境
    - 明示的に必要なパッケージをすべて指定する必要あり
 
-#### 5.3.2 Claude Desktop設定の例
-
-**注意**: 以下の例は古い設定方法です。現在は`uv run mcp install`コマンドを使用してください（上記参照）。
-
-```json
-"minerva": {
-  "command": "uv",
-  "args": [
-    "run",
-    "--with-editable",
-    ".",
-    "--with",
-    "mcp[cli]",
-    "mcp",
-    "run",
-    "/path/to/minerva/src/minerva/server.py:mcp"
-  ]
-}
-```
-
 重要: パッケージの**インストール名**（例: `python-frontmatter`）と**インポート名**（例: `import frontmatter`）が異なる場合があるため、両方の名前を正確に把握する必要があります。
 
 ## 6. テスト戦略

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -173,7 +173,7 @@ Minerva
 1. 必要な環境変数を`.env`ファイルに設定
 2. 依存パッケージのインストール: `uv` パッケージマネージャを使用
 3. MCPサーバーの起動: `uv run mcp dev server.py`
-4. Claude Desktopへのインストール: `uv run mcp install server.py --with python-frontmatter`
+4. Claude Desktopへのインストール: `uv run mcp install src/minerva/server.py:mcp -f .env --with-editable .`
 
 ### 5.3 依存関係の管理
 
@@ -193,16 +193,20 @@ Minervaプロジェクトでは、以下の2つの異なる環境での依存関
 
 #### 5.3.2 Claude Desktop設定の例
 
+**注意**: 以下の例は古い設定方法です。現在は`uv run mcp install`コマンドを使用してください（上記参照）。
+
 ```json
 "minerva": {
   "command": "uv",
   "args": [
     "run",
+    "--with-editable",
+    ".",
     "--with",
-    "mcp[cli],python-frontmatter",
+    "mcp[cli]",
     "mcp",
     "run",
-    "/path/to/minerva/server.py"
+    "/path/to/minerva/src/minerva/server.py:mcp"
   ]
 }
 ```

--- a/src/minerva/server.py
+++ b/src/minerva/server.py
@@ -1,21 +1,5 @@
-# NOTE:
-# When running this file from the command line (e.g. `uv run mcp dev src/minerva/server.py:mcp`),
-# the parent directory is automatically added to sys.path, so absolute imports like `from minerva.service import ...` work fine.
-# However, when launched from Claude Desktop (see `claude_desktop_config.json`), the sys.path may not include the parent directory.
-# In that case, adding the following lines ensures the minerva package can always be imported:
-#
-# import sys
-# import os
-# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-#
-# This guarantees the minerva package is importable regardless of the execution context.
-
-import os
-import sys
 import logging
 from pathlib import Path
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from mcp.server.fastmcp import FastMCP
 


### PR DESCRIPTION
## Summary
- Remove unnecessary sys.path manipulation code from server.py that was causing import issues
- Update installation commands to use --with-editable . option for better package recognition
- Remove redundant --with python-frontmatter since editable install handles all dependencies automatically

## Test plan
- [x] All 246 tests pass
- [x] Linting and formatting checks pass  
- [x] Installation command simplified while maintaining functionality
- [x] Documentation updated across all relevant files

🤖 Generated with [Claude Code](https://claude.ai/code)