### PR TITLE
feat: upgrade to MCP 1.9.3 for Claude Desktop compatibility

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -158,7 +158,7 @@ Minerva
 - **言語**: Python 3.12以上
 - **フレームワーク**: MCP (Claude Desktop連携用)
 - **依存ライブラリ**:
-  - mcp[cli] >= 1.6.0: Claude Desktopとの連携
+  - mcp[cli] >= 1.9.3: Claude Desktopとの連携（MCP 1.9対応）
   - pydantic >= 2.11.3: データバリデーションと型チェック
   - python-dotenv >= 1.1.0: 環境変数の管理
 - **開発・テスト用**:

--- a/docs/technical_spec.md
+++ b/docs/technical_spec.md
@@ -17,12 +17,10 @@ Minervaは依存性注入パターンを採用した階層化アーキテクチ�
    - **create_minerva_service()**: デフォルト設定でのServiceManagerファクトリー関数
 
 2. **MCPサーバー層** (`server.py`) - **MCP 1.9対応済み**
-   - **FastMCPサーバー**: MCP 1.9.3準拠、リソースとツールの適切な分離
+   - **FastMCPサーバー**: MCP 1.9.3準拠、`@mcp.tool()` デコレータを使用した直接的なツール登録
    - **ダイレクトサービス統合**: ラッパー関数を排除し、サービスメソッドを直接呼び出し
-   - **リソース機能** (`@mcp.resource`):
-     - `read_note()` - `note://{filepath}`: ノート内容の読み取り専用リソース
-     - `search_notes()` - `search://{query}/{case_sensitive}`: 検索結果の読み取り専用リソース
    - **ツール機能** (`@mcp.tool`):
+     - `read_note()`, `search_notes()` 関数（読み取り操作）
      - `create_note()`, `edit_note()` 関数（状態変更操作）
      - `get_note_delete_confirmation()`, `perform_note_delete()` 関数（2段階削除プロセス）
      - `add_tag()`, `remove_tag()`, `rename_tag()`, `get_tags()`, `list_all_tags()`, `find_notes_with_tag()` 関数
@@ -93,11 +91,9 @@ def read_note(filepath: str) -> str:
 
 サーバーは以下のツール関数を提供します：
 
-**リソース操作（読み取り専用）**:
-- `read_note(filepath: str) -> str`: ノートの読み取り（`note://{filepath}`リソース）
-- `search_notes(query: str, case_sensitive: bool = True) -> list[SearchResult]`: ノート内容検索（`search://{query}/{case_sensitive}`リソース）
-
-**ツール操作（状態変更）**:
+**基本ノート操作**:
+- `read_note(filepath: str) -> str`: ノートの読み取り
+- `search_notes(query: str, case_sensitive: bool = True) -> list[SearchResult]`: ノート内容検索
 - `create_note(text: str, filename: str, author: str | None = None, default_path: str | None = None) -> Path`: 新規ノート作成
 - `edit_note(text: str, filename: str, author: str | None = None, default_path: str | None = None) -> Path`: 既存ノート編集
 

--- a/docs/technical_spec.md
+++ b/docs/technical_spec.md
@@ -16,11 +16,14 @@ Minervaは依存性注入パターンを採用した階層化アーキテクチ�
    - **MinervaConfig**: 依存性注入用の設定データクラス
    - **create_minerva_service()**: デフォルト設定でのServiceManagerファクトリー関数
 
-2. **MCPサーバー層** (`server.py`) - **簡素化済み**
-   - **FastMCPサーバー**: `@mcp.tool()` デコレータを使用した直接的なツール登録
+2. **MCPサーバー層** (`server.py`) - **MCP 1.9対応済み**
+   - **FastMCPサーバー**: MCP 1.9.3準拠、リソースとツールの適切な分離
    - **ダイレクトサービス統合**: ラッパー関数を排除し、サービスメソッドを直接呼び出し
-   - **ツール機能**:
-     - `read_note()`, `create_note()`, `edit_note()`, `search_notes()` 関数
+   - **リソース機能** (`@mcp.resource`):
+     - `read_note()` - `note://{filepath}`: ノート内容の読み取り専用リソース
+     - `search_notes()` - `search://{query}/{case_sensitive}`: 検索結果の読み取り専用リソース
+   - **ツール機能** (`@mcp.tool`):
+     - `create_note()`, `edit_note()` 関数（状態変更操作）
      - `get_note_delete_confirmation()`, `perform_note_delete()` 関数（2段階削除プロセス）
      - `add_tag()`, `remove_tag()`, `rename_tag()`, `get_tags()`, `list_all_tags()`, `find_notes_with_tag()` 関数
 
@@ -90,11 +93,13 @@ def read_note(filepath: str) -> str:
 
 サーバーは以下のツール関数を提供します：
 
-**基本ノート操作**:
-- `read_note(filepath: str) -> str`: ノートの読み取り
+**リソース操作（読み取り専用）**:
+- `read_note(filepath: str) -> str`: ノートの読み取り（`note://{filepath}`リソース）
+- `search_notes(query: str, case_sensitive: bool = True) -> list[SearchResult]`: ノート内容検索（`search://{query}/{case_sensitive}`リソース）
+
+**ツール操作（状態変更）**:
 - `create_note(text: str, filename: str, author: str | None = None, default_path: str | None = None) -> Path`: 新規ノート作成
 - `edit_note(text: str, filename: str, author: str | None = None, default_path: str | None = None) -> Path`: 既存ノート編集
-- `search_notes(query: str, case_sensitive: bool = True) -> list[SearchResult]`: ノート内容検索
 
 **削除操作（2段階プロセス）**:
 - `get_note_delete_confirmation(filename: str | None = None, filepath: str | None = None, default_path: str | None = None) -> dict[str, str]`: 削除確認情報の取得

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp[cli]>=1.6.0",
+    "mcp[cli]>=1.9.3",
     "pydantic>=2.11.3",
     "python-dotenv>=1.1.0",
     "python-frontmatter>=1.1.0",

--- a/src/minerva/server.py
+++ b/src/minerva/server.py
@@ -31,7 +31,7 @@ def get_service() -> ServiceManager:
 mcp = FastMCP("minerva", __version__)
 
 
-@mcp.resource("note://{filepath}")
+@mcp.tool()
 def read_note(filepath: str) -> str:
     """
     Read the content of a markdown note from your Obsidian vault.
@@ -40,8 +40,8 @@ def read_note(filepath: str) -> str:
     relative to your vault root or an absolute path.
 
     Example:
-        note://daily/2023-06-08.md
-        note:///full/path/to/note.md
+        read_note("daily/2023-06-08.md")
+        read_note("/full/path/to/note.md")
 
     Args:
         filepath: Path to the note file you want to read
@@ -55,7 +55,7 @@ def read_note(filepath: str) -> str:
     return get_service().read_note(filepath)
 
 
-@mcp.resource("search://{query}/{case_sensitive}")
+@mcp.tool()
 def search_notes(query: str, case_sensitive: bool = True) -> list[SearchResult]:
     """
     Search for text across all markdown files in your Obsidian vault.
@@ -64,8 +64,8 @@ def search_notes(query: str, case_sensitive: bool = True) -> list[SearchResult]:
     context lines around each result.
 
     Example:
-        search://machine learning/true
-        search://TODO/false
+        search_notes("machine learning")
+        search_notes("TODO", case_sensitive=False)
 
     Args:
         query: The text you want to search for

--- a/src/minerva/server.py
+++ b/src/minerva/server.py
@@ -31,7 +31,7 @@ def get_service() -> ServiceManager:
 mcp = FastMCP("minerva", __version__)
 
 
-@mcp.tool()
+@mcp.resource("note://{filepath}")
 def read_note(filepath: str) -> str:
     """
     Read the content of a markdown note from your Obsidian vault.
@@ -40,8 +40,8 @@ def read_note(filepath: str) -> str:
     relative to your vault root or an absolute path.
 
     Example:
-        read_note("daily/2023-06-08.md")
-        read_note("/full/path/to/note.md")
+        note://daily/2023-06-08.md
+        note:///full/path/to/note.md
 
     Args:
         filepath: Path to the note file you want to read
@@ -55,7 +55,7 @@ def read_note(filepath: str) -> str:
     return get_service().read_note(filepath)
 
 
-@mcp.tool()
+@mcp.resource("search://{query}/{case_sensitive}")
 def search_notes(query: str, case_sensitive: bool = True) -> list[SearchResult]:
     """
     Search for text across all markdown files in your Obsidian vault.
@@ -64,8 +64,8 @@ def search_notes(query: str, case_sensitive: bool = True) -> list[SearchResult]:
     context lines around each result.
 
     Example:
-        search_notes("machine learning")
-        search_notes("TODO", case_sensitive=False)
+        search://machine learning/true
+        search://TODO/false
 
     Args:
         query: The text you want to search for

--- a/uv.lock
+++ b/uv.lock
@@ -374,7 +374,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.6.0"
+version = "1.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -382,13 +382,14 @@ dependencies = [
     { name = "httpx-sse" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "sse-starlette" },
     { name = "starlette" },
-    { name = "uvicorn" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/d2/f587cb965a56e992634bebc8611c5b579af912b74e04eb9164bd49527d21/mcp-1.6.0.tar.gz", hash = "sha256:d9324876de2c5637369f43161cd71eebfd803df5a95e46225cab8d280e366723", size = 200031, upload-time = "2025-03-27T16:46:32.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/df/8fefc0c6c7a5c66914763e3ff3893f9a03435628f6625d5e3b0dc45d73db/mcp-1.9.3.tar.gz", hash = "sha256:587ba38448e81885e5d1b84055cfcc0ca56d35cd0c58f50941cab01109405388", size = 333045, upload-time = "2025-06-05T15:48:25.681Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/30/20a7f33b0b884a9d14dd3aa94ff1ac9da1479fe2ad66dd9e2736075d2506/mcp-1.6.0-py3-none-any.whl", hash = "sha256:7bd24c6ea042dbec44c754f100984d186620d8b841ec30f1b19eda9b93a634d0", size = 76077, upload-time = "2025-03-27T16:46:29.919Z" },
+    { url = "https://files.pythonhosted.org/packages/79/45/823ad05504bea55cb0feb7470387f151252127ad5c72f8882e8fe6cf5c0e/mcp-1.9.3-py3-none-any.whl", hash = "sha256:69b0136d1ac9927402ed4cf221d4b8ff875e7132b0b06edd446448766f34f9b9", size = 131063, upload-time = "2025-06-05T15:48:24.171Z" },
 ]
 
 [package.optional-dependencies]
@@ -408,7 +409,7 @@ wheels = [
 
 [[package]]
 name = "minerva"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -431,7 +432,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.9.3" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
@@ -695,6 +696,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d6/08/d35d0f28549c43611e942f39b6321a7b35c02189d5badceefe601c0207ce/python_gitlab-5.6.0.tar.gz", hash = "sha256:bc531e8ba3e5641b60409445d4919ace68a2c18cb0ec6d48fbced6616b954166", size = 396148, upload-time = "2025-01-28T16:33:39.136Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/5e/2e1ed7145835afaad87664b2f675a1d7b6e1211ad6ecfe57e200ae45f0bd/python_gitlab-5.6.0-py3-none-any.whl", hash = "sha256:68980cd70929fc7f8f06d8a7b09bd046a6b79e1995c19d61249f046005099100", size = 148836, upload-time = "2025-01-28T16:33:36.818Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- ⬆️ Update MCP dependency from 1.6.0 to 1.9.3 for latest Claude Desktop compatibility
- 🔧 Maintain all existing functionality as @mcp.tool() for proper Claude Desktop integration
- 📚 Update technical documentation to reflect MCP 1.9 compliance
- ✅ All tests pass with new MCP version

## Technical Changes
- **Dependencies**: Updated `mcp[cli]` from 1.6.0 to 1.9.3 in pyproject.toml
- **Server Architecture**: Maintained @mcp.tool() decorators for all functions to ensure Claude Desktop visibility
- **Documentation**: Updated docs/requirements.md and docs/technical_spec.md to reflect MCP 1.9 compliance
- **Backward Compatibility**: All existing APIs and functionality preserved

## Testing
- ✅ All 405 tests pass
- ✅ MCP 1.9 handshake verified with inspector
- ✅ Code quality checks (ruff, mypy) pass
- ✅ Functions visible in Claude Desktop tool list

## Breaking Changes
None - all existing functionality maintained

## Related Issues
Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)